### PR TITLE
Add section with instructions for Cori GPU

### DIFF
--- a/job_scripts/cori-gpu/cori.MPI.CUDA.gpu.2nodes.slurm
+++ b/job_scripts/cori-gpu/cori.MPI.CUDA.gpu.2nodes.slurm
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Number of nodes:
+#SBATCH --nodes=2
+#
+############################################
+# Cori GPU node configuration
+#
+# This lets SLURM pick the right number of
+# MPI tasks given the number of nodes
+# requested above. These settings will
+# assign 1 MPI task per GPU.
+#
+# (generally you won't need to change this)
+############################################
+#
+# Requests Cori GPU nodes:
+#SBATCH --constraint=gpu
+#
+# Each GPU node has 40 physical CPU cores
+# (w/ 2 hyperthreads, so 80 virtual CPU cores)
+# and 8 NVIDIA Tesla V100 GPUs.
+#
+# GPU: Assign 1 MPI tasks to each GPU
+#SBATCH --tasks-per-node=8
+#
+# We want all 8 GPUs on the node
+#SBATCH --gres=gpu:8
+#
+# Since we want the entire node (all the GPUs)
+# with 8 MPI tasks, this is 80/8 = 10 virtual CPUs
+# per MPI task.
+#SBATCH --cpus-per-task=10
+#
+#################
+# Queue & Job
+#################
+#
+# Which queue to run in: debug, regular, premium, etc. ...
+# For now, don't use --qos
+## SBATCH --qos=debug
+#
+# Run for this much walltime: hh:mm:ss
+#SBATCH --time=00:15:00
+#
+# Use this job name:
+#SBATCH -J castro_gpu_job
+#
+# Send notification emails here:
+#SBATCH --mail-user=[your email address]
+#SBATCH --mail-type=ALL
+#
+# Which allocation to use:
+#SBATCH -A [your allocation ID, e.g. mABCD]
+
+# On the compute node, change to the directory we submitted from
+cd $SLURM_SUBMIT_DIR
+
+# OpenMP Configuration
+# This configuration ignores the hyperthreads
+# and assigns 1 OpenMP thread/physical core
+export OMP_PLACES=cores
+export OMP_PROC_BIND=true
+export OMP_NUM_THREADS=5
+
+srun --cpu_bind=cores ./Castro3d.gnu.TPROF.MPI.CUDA.ex inputs.3d.sph.testsuite

--- a/sphinx_docs/source/nersc-compilers.rst
+++ b/sphinx_docs/source/nersc-compilers.rst
@@ -100,3 +100,77 @@ When running MAESTROeX, we seem to need::
 
 otherwise we get an ``Erroneous arithmetic error``.
 
+
+
+Cori GPU
+--------
+
+To use the Cori GPU system, you first need to load the ``cgpu`` module::
+
+  module load cgpu
+
+This will ensure the correct OpenMPI module is loaded in the next section.
+
+Loading ``cgpu`` will also let you check on your running jobs using ``squeue``.
+
+Compiling with GCC + CUDA
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We use the gcc, CUDA, and OpenMPI modules for Cori GPU, so load them in this
+order::
+
+  module swap PrgEnv-intel PrgEnv-gnu
+  module load gcc
+  module load cuda
+  module load openmpi
+  module load python3
+
+Then to compile, we'll need to get an interactive session on a Cori GPU node.
+This example gets 1 Cori GPU node with 1 GPU/node and 10 CPU cores/node for 60
+minutes, reserving 30GB of RAM per node::
+
+  salloc -C gpu --gres=gpu:1 -N 1 -t 60 -c 10 --mem=30GB -A [your allocation, e.g. mABCD] [--exclusive]
+
+.. note::
+
+  If the optional ``--exclusive`` argument is present, then your job will have
+  exclusive use of the nodes you requested for the duration of the job.  The
+  default behavior on Cori GPU is for jobs to share the GPU nodes, since there
+  are a limited number.
+
+Build, e.g. the Castro Sedov hydro test problem::
+
+  make -j COMP=gnu TINY_PROFILE=TRUE USE_MPI=TRUE USE_OMP=FALSE USE_CUDA=TRUE
+
+Running on Cori GPU
+^^^^^^^^^^^^^^^^^^^
+
+Use a SLURM script to set 1 MPI rank per GPU. In this example, we're using 2 nodes, each with 8 GPUs.
+
+Sample SLURM script ``cori.MPI.CUDA.gpu.2nodes.slurm``: 
+
+.. literalinclude:: ../../job_scripts/cori-gpu/cori.MPI.CUDA.gpu.2nodes.slurm
+                    :language: sh
+                    :linenos:
+
+.. note::
+
+  Replace ``[your email address]`` and ``[your allocation]`` with your info
+  (omitting the brackets).
+
+.. note::
+
+  It is important to submit the Cori GPU SLURM script from a Cori login node.
+  If you submit the script from your Cori GPU interactive session, the memory
+  constraints you passed to ``salloc`` will conflict with the GPU options
+  specified in the SLURM script.
+
+So we'll next submit the SLURM script from a Cori login node, with the above
+modules loaded::
+
+  sbatch [--exclusive] cori.MPI.CUDA.gpu.2nodes.slurm
+
+(The optional ``--exclusive`` argument has the same meaning as for ``salloc`` above.)
+
+We can monitor the job by checking ``squeue -u [user]`` as usual with the
+``cgpu`` module loaded.

--- a/sphinx_docs/source/nersc-compilers.rst
+++ b/sphinx_docs/source/nersc-compilers.rst
@@ -107,6 +107,7 @@ Cori GPU
 
 To use the Cori GPU system, you first need to load the ``cgpu`` module::
 
+  module purge
   module load cgpu
 
 This will ensure the correct OpenMPI module is loaded in the next section.
@@ -119,7 +120,7 @@ Compiling with GCC + CUDA
 We use the gcc, CUDA, and OpenMPI modules for Cori GPU, so load them in this
 order::
 
-  module swap PrgEnv-intel PrgEnv-gnu
+  module load PrgEnv-gnu
   module load gcc
   module load cuda
   module load openmpi

--- a/sphinx_docs/source/nersc-compilers.rst
+++ b/sphinx_docs/source/nersc-compilers.rst
@@ -147,7 +147,9 @@ Running on Cori GPU
 
 Use a SLURM script to set 1 MPI rank per GPU. In this example, we're using 2 nodes, each with 8 GPUs.
 
-Sample SLURM script ``cori.MPI.CUDA.gpu.2nodes.slurm``: 
+Sample SLURM script ``cori.MPI.CUDA.gpu.2nodes.slurm``, for this and other Cori
+GPU SLURM scripts, see
+`our Cori GPU SLURM scripts on GitHub <https://github.com/AMReX-Astro/workflow/blob/main/job_scripts/cori-gpu>`_
 
 .. literalinclude:: ../../job_scripts/cori-gpu/cori.MPI.CUDA.gpu.2nodes.slurm
                     :language: sh


### PR DESCRIPTION
This adds a section to the "Compiling at NERSC" page with instructions for using Cori GPU, a simple SLURM script, and a link to this and other SLURM scripts by @jmsexton03 .
