### PR TITLE
Fix perlmutter submit script logic

### DIFF
--- a/job_scripts/perlmutter/perlmutter.submit
+++ b/job_scripts/perlmutter/perlmutter.submit
@@ -28,11 +28,8 @@ function find_chk_file {
     restartFile=""
     for f in ${temp_files}
     do
-        # the Header is the last thing written -- check if it's there, otherwise,
-        # fall back to the second-to-last check file written
-        if [ ! -f ${f}/Header ]; then
-            restartFile=""
-        else
+        # the Header is the last thing written -- if it's there, update the restart file
+        if [ -f ${f}/Header ]; then
             restartFile="${f}"
         fi
     done


### PR DESCRIPTION
The second-to-last check file goes through the loop first, so we don't want to reset restartFile to empty string ("") if the last check file is incomplete.