### PR TITLE
Work around intermittent Summit scratch FS errors

### DIFF
--- a/job_scripts/summit/submit_restart.sh
+++ b/job_scripts/summit/submit_restart.sh
@@ -47,10 +47,14 @@ function find_chk_file {
     do
         # the Header is the last thing written -- if it's there, update the restart file
         if [ -f ${f}/Header ]; then
-            restartFile="${f}"
+            # The scratch FS sometimes gives I/O errors when trying to read
+            # from recently-created files, which crashes Castro. Avoid this by
+            # making sure we can read from all the data files.
+            if head --quiet -c1 "${f}/Header" "${f}"/Level_*/* >/dev/null; then
+                restartFile="${f}"
+            fi
         fi
     done
-
 }
 
 # look for 7-digit chk files

--- a/job_scripts/summit/summit_template.sh
+++ b/job_scripts/summit/summit_template.sh
@@ -35,7 +35,12 @@ function find_chk_file {
     do
         # the Header is the last thing written -- if it's there, update the restart file
         if [ -f ${f}/Header ]; then
-            restartFile="${f}"
+            # The scratch FS sometimes gives I/O errors when trying to read
+            # from recently-created files, which crashes Castro. Avoid this by
+            # making sure we can read from all the data files.
+            if head --quiet -c1 "${f}/Header" "${f}"/Level_*/* >/dev/null; then
+                restartFile="${f}"
+            fi
         fi
     done
 }


### PR DESCRIPTION
In the last month or so, I've had several job chains die with I/O errors when trying to restart from the latest checkpoint file. All the files show up fine with `ls`, but reading from one or two of them fails for up to ~10-15 minutes after they were created. This PR works around this by restarting from the previous checkpoint file if any of the files can't be read.