### PR TITLE
Make sure frontier.slurm only runs on Frontier

### DIFF
--- a/job_scripts/frontier/frontier.slurm
+++ b/job_scripts/frontier/frontier.slurm
@@ -4,6 +4,7 @@
 #SBATCH -o %x-%j.out
 #SBATCH -t 02:00:00
 #SBATCH -p batch
+#SBATCH --cluster frontier
 # here N is the number of compute nodes
 #SBATCH -N 4
 #SBATCH --ntasks-per-node=8

--- a/job_scripts/slurm/chainslurm.sh
+++ b/job_scripts/slurm/chainslurm.sh
@@ -35,7 +35,7 @@ then
     echo chaining $numjobs jobs
     
     echo starting job 1 with no dependency
-    aout=`sbatch --parsable ${script}`
+    aout=`sbatch --parsable ${script} | cut -d';' -f1`
     echo "   " jobid: $aout
     echo " "
     oldjob=$aout
@@ -48,7 +48,7 @@ fi
 for count in `seq $firstcount 1 $numjobs`
 do
   echo starting job $count to depend on $oldjob
-  aout=`sbatch --parsable -d afterany:${oldjob} ${script}`
+  aout=`sbatch --parsable -d afterany:${oldjob} ${script} | cut -d';' -f1`
   echo "   " jobid: $aout
   echo " "
   oldjob=$aout


### PR DESCRIPTION
I've accidentally submitted this from Andes, and vice versa for the analysis scripts. This also fixes the sbatch output parsing in chainslurm.sh when --cluster is passed (it outputs the job id and cluster separated by a semicolon).